### PR TITLE
Remove Oxide.ts re-export

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,9 +20,9 @@ const plugins = [
 
 export default [
   {
-    input: "src/common/index.ts",
+    input: "src/index.ts",
     output: {
-      file: "dist/common/index.js",
+      file: "dist/index.js",
       format: "umd",
       name: "GMETransformations",
     },

--- a/src/common/ModelTransformation.ts
+++ b/src/common/ModelTransformation.ts
@@ -1,5 +1,4 @@
 import { None, Option, Some } from "oxide.ts";
-export { None, Some } from "oxide.ts";
 
 //@ts-ignore
 import type from "webgme";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./common/index";

--- a/test/common/ModelTransformation.spec.js
+++ b/test/common/ModelTransformation.spec.js
@@ -4,9 +4,9 @@
 
 const testFixture = require("../globals");
 const assert = require("assert");
+const { Some } = require("oxide.ts");
 const {
   ModelTransformation: Transformation,
-  Some,
   Pattern,
   Property,
   AnyNode,
@@ -17,7 +17,7 @@ const {
   GMEContext,
   Relation,
 } = require(
-  "../../dist/common/index",
+  "../../dist/index",
 );
 
 describe("ModelTransformation", function () {


### PR DESCRIPTION
This was causing problems with using the built version of the library.
